### PR TITLE
Added to prompt for short responses and changed function name

### DIFF
--- a/zsh-gpt.plugin.zsh
+++ b/zsh-gpt.plugin.zsh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 
-g() {
+gpt() {
   if [[ ! $+commands[curl] ]]; then echo "Curl must be installed."; return 1; fi
   if [[ ! $+commands[jq] ]]; then echo "Jq must be installed."; return 1; fi
   if [[ ! -v OPENAI_API_KEY ]]; then echo "Must set OPENAI_API_KEY to your API key"; return 1; fi
@@ -10,6 +10,6 @@ g() {
     -H "Authorization: Bearer $OPENAI_API_KEY" \
     -d '{
     "model": "gpt-3.5-turbo",
-    "messages": [{"role": "user", "content": "'"$*"'"}]
+    "messages": [{"role": "system", "content": "you''re an in-line zsh assistant running on linux. Your task is to answer the questions without any commentation at all, providing only the code to run on terminal. You can assume that the user understands that they need to fill in placeholders like <PORT>. Do not explain the answers, just give code. Keep the responses to one-liner answers as much as possible"}, {"role": "user", "content": "'"$*"'"}]
   }' | jq -r '.choices[0].message.content'
 }

--- a/zsh-gpt.plugin.zsh
+++ b/zsh-gpt.plugin.zsh
@@ -10,6 +10,6 @@ gpt() {
     -H "Authorization: Bearer $OPENAI_API_KEY" \
     -d '{
     "model": "gpt-3.5-turbo",
-    "messages": [{"role": "system", "content": "you''re an in-line zsh assistant running on linux. Your task is to answer the questions without any commentation at all, providing only the code to run on terminal. You can assume that the user understands that they need to fill in placeholders like <PORT>. Do not explain the answers, just give code. Keep the responses to one-liner answers as much as possible"}, {"role": "user", "content": "'"$*"'"}]
+    "messages": [{"role": "system", "content": "you''re an in-line zsh assistant running on linux. Your task is to answer the questions without any commentation at all, providing only the code to run on terminal. You can assume that the user understands that they need to fill in placeholders like <PORT>. You''re not allowed to explain anything and you''re not a chatbot. You only provide shell commands or code. Keep the responses to one-liner answers as much as possible. Do not decorate the answer with tickmarks"}, {"role": "user", "content": "'"$*"'"}]
   }' | jq -r '.choices[0].message.content'
 }


### PR DESCRIPTION
Long responses take time and are inconvenient to copy-paste. I added a system prompt to tell gpt to give one-liners without commentation for response. Also changed `g` to `gpt` because `g` is often reserved for `git` in zsh